### PR TITLE
Migrate from `name.full()` to `name_full()` to future-proof editing a user into an organization

### DIFF
--- a/docassemble/NameChangeAdult/data/questions/name_change_adult.yml
+++ b/docassemble/NameChangeAdult/data/questions/name_change_adult.yml
@@ -621,7 +621,7 @@ question: |
     Does your spouse have any arrests for which charges have not been filed?
     % endif
   % else:
-  Does ${x[i].new.name.full(middle='full')} (AKA ${x[i].name.full(middle='full')}) have any arrests for which charges have not been filed?
+  Does ${x[i].new.name_full()} (AKA ${x[i].name_full()}) have any arrests for which charges have not been filed?
   % endif
 subquestion: |
   If you were arrested but did not go to court or see a judge, then you were probably not charged with a crime. That means charges are pending.
@@ -640,7 +640,7 @@ question: |
     Does your spouse have any pending misdemeanor or felony charges?
     % endif
   % else:
-  Does ${x[i].new.name.full(middle='full')} (AKA ${x[i].name.full(middle='full')}) have any pending misdemeanor or felony charges?
+  Does ${x[i].new.name_full()} (AKA ${x[i].name_full()}) have any pending misdemeanor or felony charges?
   % endif
 subquestion: |
   % if interview_type == 'adult':
@@ -650,7 +650,7 @@ subquestion: |
     In other words, does your spouse have any ongoing criminal cases against them for misdemeanor or felony offenses?
     % endif
   % else:
-    In other words, does ${x[i].new.name.full(middle='full')} (AKA ${x[i].name.full(middle='full')}) have any ongoing criminal cases against them for misdemeanor or felony offenses?
+    In other words, does ${x[i].new.name_full()} (AKA ${x[i].name_full()}) have any ongoing criminal cases against them for misdemeanor or felony offenses?
   % endif
 fields:
   - no label: x[i].pending_charges
@@ -666,7 +666,7 @@ question: |
     Does your spouse have any convictions or were they placed on probation for any misdemeanors in Illinois?
     % endif
   % else:
-  Does ${x[i].new.name.full(middle='full')} (AKA ${x[i].name.full(middle='full')}) have any convictions or were they placed on probation for any misdemeanors?
+  Does ${x[i].new.name_full()} (AKA ${x[i].name_full()}) have any convictions or were they placed on probation for any misdemeanors?
   % endif
 subquestion: |
   We will ask about misdemeanors in other states on another screen.
@@ -689,7 +689,7 @@ question: |
     Does your spouse have any convictions or were they placed on probation for any misdemeanors outside Illinois?
     % endif
   % else:
-  Does ${x[i].new.name.full(middle='full')} (AKA ${x[i].name.full(middle='full')}) have any convictions or were they placed on probation for any misdemeanors?
+  Does ${x[i].new.name_full()} (AKA ${x[i].name_full()}) have any convictions or were they placed on probation for any misdemeanors?
   % endif
 subquestion: |
   **Note:** These do not include misdemeanors in Illinois.
@@ -712,7 +712,7 @@ question: |
     Does your spouse have any convictions or were they placed on probation for any felonies?
     % endif
   % else:
-  Does ${x[i].new.name.full(middle='full')} (AKA ${x[i].name.full(middle='full')}) have any convictions or were they placed on probation for any felonies?
+  Does ${x[i].new.name_full()} (AKA ${x[i].name_full()}) have any convictions or were they placed on probation for any felonies?
   % endif
 subquestion: |
   These can be felonies in Illinois or any other state.
@@ -735,7 +735,7 @@ question: |
     Does your spouse have any convictions or were they placed on probation for a crime that required them to register?
     % endif
   % else:
-  Does ${x[i].new.name.full(middle='full')} (AKA ${x[i].name.full(middle='full')}) have any convictions or were they placed on probation for a crime that required them register?
+  Does ${x[i].new.name_full()} (AKA ${x[i].name_full()}) have any convictions or were they placed on probation for a crime that required them register?
   % endif
 subquestion: |
   These include crimes that require registration under the:
@@ -848,7 +848,7 @@ question: |
     Does your spouse have any convictions or were they placed on probation for identity theft?
     % endif
   % else:
-  Does ${x[i].new.name.full(middle='full')} (AKA ${x[i].name.full(middle='full')}) have any convictions or were they placed on probation for identity theft?
+  Does ${x[i].new.name_full()} (AKA ${x[i].name_full()}) have any convictions or were they placed on probation for identity theft?
   % endif
 subquestion: |
   This includes **identity theft** or **aggravated identity theft**.
@@ -862,7 +862,7 @@ subquestion: |
     Your spouse can still request a name change even if you answer **Yes**.
     % endif
   % else:
-  You can still request a name change for ${x[i].new.name.full(middle='full')} (AKA ${x[i].name.full(middle='full')}) even if you answer **Yes**.
+  You can still request a name change for ${x[i].new.name_full()} (AKA ${x[i].name_full()}) even if you answer **Yes**.
   % endif
 fields:
   - no label: x[i].id_theft
@@ -881,7 +881,7 @@ subquestion: |
     For these convictions or probations, you must enter more information on your spouse's name change request:
     % endif
   % else:
-  For these convictions or probations of ${x[i].new.name.full(middle='full')} (AKA ${x[i].name.full(middle='full')}), you must enter more information:
+  For these convictions or probations of ${x[i].new.name_full()} (AKA ${x[i].name_full()}), you must enter more information:
   % endif
 
   % if x[i].felonies:
@@ -911,7 +911,7 @@ subquestion: |
     For any of the following convictions or probations, you must enter more information on your spouse's name change request:
     % endif
   % else:
-  For any of the following convictions or probations of ${x[i].new.name.full(middle='full')} (AKA ${x[i].name.full(middle='full')}), you must enter more information:
+  For any of the following convictions or probations of ${x[i].new.name_full()} (AKA ${x[i].name_full()}), you must enter more information:
   % endif
   
   % if x[i].felonies:
@@ -957,7 +957,7 @@ subquestion: |
     For any of the following convictions or probations, you must enter more information on your spouse's name change request:
     % endif
   % else:
-  For these convictions or probations of ${x[i].new.name.full(middle='full')} (AKA ${x[i].name.full(middle='full')}), you must enter more information on your name change request:
+  For these convictions or probations of ${x[i].new.name_full()} (AKA ${x[i].name_full()}), you must enter more information on your name change request:
   % endif
 
   % if x[i].felonies:
@@ -1227,16 +1227,16 @@ subject: |
   **What should my answer look like?**
 content: |  
   % if children.number_gathered() == 1:
-  This explanation will go on your *Motion to Waive Notice and Publication*. You should explain why giving or publishing notice would put ${children[0].new.name.full(middle='full')} (AKA ${children[0].name.full(middle='full')}) at risk of physical harm or discrimination.
+  This explanation will go on your *Motion to Waive Notice and Publication*. You should explain why giving or publishing notice would put ${children[0].new.name_full()} (AKA ${children[0].name_full()}) at risk of physical harm or discrimination.
   % else:
   This explanation will go on your *Motion to Waive Notice and Publication*. You should explain why giving or publishing notice would put your children at risk of physical harm or discrimination.
   % endif
 
   Here are some examples: 
   
-  "I need to change ${children[0].name.full(middle='full')}'s name to ${children[0].new.name.full(middle='full')} because we are trying to get away from my ex-boyfriend. He has abused ${children[0].name.full(middle='full')} in the past. I am afraid he will hurt ${children[0].name.full(middle='full')} if he learns about this name change request."
+  "I need to change ${children[0].name_full()}'s name to ${children[0].new.name_full()} because we are trying to get away from my ex-boyfriend. He has abused ${children[0].name_full()} in the past. I am afraid he will hurt ${children[0].name_full()} if he learns about this name change request."
   
-  "${children[0].name.full(middle='full')} wants to change their name to ${children[0].new.name.full(middle='full')} as part of a gender transition. I am afraid publishing notice of this change in the newspaper could lead to my child and I experiencing discrimination or targeted harassment."
+  "${children[0].name_full()} wants to change their name to ${children[0].new.name_full()} as part of a gender transition. I am afraid publishing notice of this change in the newspaper could lead to my child and I experiencing discrimination or targeted harassment."
 ---
 template: adult_notice_waiver_example
 subject: |
@@ -1756,7 +1756,7 @@ id: e-signature
 question: |
   Do you want to add your e-signature to your name change forms?
 subquestion: |
-  This program can put “**/s/ ${users[0].name.full(middle='full')}**” where you would sign your name. The court will accept this as your signature.
+  This program can put “**/s/ ${users[0].name_full()}**” where you would sign your name. The court will accept this as your signature.
 
   If you do not add your **{e-signature}**, you must sign your paper forms before you file them.
 
@@ -1780,7 +1780,7 @@ id: spouse e-signature
 question: |
   Does your spouse want to add their e-signature to their name change forms?
 subquestion: |
-  This program can put “**/s/ ${users[1].name.full(middle='full')}**” where they would sign their name. The court will accept this as their signature.
+  This program can put “**/s/ ${users[1].name_full()}**” where they would sign their name. The court will accept this as their signature.
 
   If they do not add their **{e-signature}** now, they must sign the paper forms before you file them.
   
@@ -1991,7 +1991,7 @@ attachment:
   pdf template file: name_change_request.pdf
   fields:
     - "trial_court_county": ${ case_county }
-    - "user__1": ${ users[0].name.full(middle="full") }
+    - "user__1": ${ users[0].name_full() }
     - "user_name_first": ${ users[0].name.first }
     - "user_name_middle": ${ users[0].name.middle }
     - "user_name_last": |
@@ -2169,15 +2169,15 @@ attachment:
         No
         % endif
         % endif
-    - "user_signature": ${ users[0].name.full(middle="full") if e_signature else '' }
-    - "user__2": ${ users[0].name.full(middle="full") }
+    - "user_signature": ${ users[0].name_full() if e_signature else '' }
+    - "user__2": ${ users[0].name_full() }
     - "user_address": ${ users[0].address.on_one_line(bare=True) }
     - "user_hide_address_cb": ${ True if hide_address else '' }
     - "user_phone": ${ phone_number_formatted(users[0].phone_number) }
     - "user_atty_number": ${ '' }
     - "user_email": ${ users[0].email if users[0].email_notice else '' }
-    - "spouse_signature": ${ users[1].name.full(middle="full") if e_signature_spouse and change_spouse_name == "Yes" else '' }
-    - "spouse_name": ${ users[1].name.full(middle="full") if change_spouse_name == "Yes" else '' }
+    - "spouse_signature": ${ users[1].name_full() if e_signature_spouse and change_spouse_name == "Yes" else '' }
+    - "spouse_name": ${ users[1].name_full() if change_spouse_name == "Yes" else '' }
     - "spouse_address": ${ users[1].address.on_one_line(bare=True) if change_spouse_name == "Yes" else '' }
     - "spouse_hide_address_cb": ${ True if spouse_hide_address else '' }
     - "spouse_phone": ${ phone_number_formatted(users[1].phone_number) if change_spouse_name == "Yes" else '' }
@@ -2193,7 +2193,7 @@ attachment:
   pdf template file: name_change_additional_criminal_history.pdf
   fields:
     - "trial_court_county": ${ case_county }
-    - "user__1": ${ users[0].name.full(middle="full") }
+    - "user__1": ${ users[0].name_full() }
     - "user_offense_name_4": ${ users[0].convictions[3].name.text }
     - "user_conviction_date_4": ${ format_date(users[0].convictions[3].date, format='MM/dd/yyyy') }
     - "user_sentence_4": ${ users[0].convictions[3].sentence }
@@ -2312,7 +2312,7 @@ attachment:
   pdf template file: name_change_additional_criminal_history.pdf
   fields:
     - "trial_court_county": ${ case_county }
-    - "user__1": ${ users[1].name.full(middle="full") }
+    - "user__1": ${ users[1].name_full() }
     - "user_offense_name_4": ${ users[1].convictions[3].name.text }
     - "user_conviction_date_4": ${ format_date(users[1].convictions[3].date, format='MM/dd/yyyy') }
     - "user_sentence_4": ${ users[1].convictions[3].sentence }
@@ -2431,7 +2431,7 @@ attachment:
   pdf template file: motion_to_waive_notice.pdf
   fields:      
     - "trial_court_county": ${ case_county }
-    - "user__1": ${ users[0].name.full(middle="full") }
+    - "user__1": ${ users[0].name_full() }
     - "waiver_order_cb": ${ True if waiver_reason['order'] == True else '' }
     - "protective_order_op": ${ True if protective_order['op'] == True else '' }
     - "protective_order_snco": ${ True if protective_order['snco'] == True else '' }
@@ -2455,8 +2455,8 @@ attachment:
     - "order_county_4": ${ orders[3].name.text if waiver_reason['order'] == True else '' }
     - "order_state_4": ${ orders[3].state if waiver_reason['order'] == True else '' }
     - "order_case_number_4": ${ orders[3].number if waiver_reason['order'] == True else '' }
-    - "user_signature": ${ users[0].name.full(middle="full") if e_signature else '' }
-    - "user__2": ${ users[0].name.full(middle="full") }
+    - "user_signature": ${ users[0].name_full() if e_signature else '' }
+    - "user__2": ${ users[0].name_full() }
     - "user_address": ${ users[0].address.on_one_line(bare=True) }
     - "user_hide_address_cb": ${ True if hide_address else '' }
     - "user_phone": ${ phone_number_formatted(users[0].phone_number) }
@@ -2472,7 +2472,7 @@ attachment:
   pdf template file: motion_to_waive_notice.pdf
   fields:      
     - "trial_court_county": ${ case_county }
-    - "user__1": ${ users[1].name.full(middle="full") }
+    - "user__1": ${ users[1].name_full() }
     - "waiver_order_cb": ${ True if spouse_waiver_reason['order'] == True else '' }
     - "protective_order_op": ${ True if spouse_protective_order['op'] == True else '' }
     - "protective_order_snco": ${ True if spouse_protective_order['snco'] == True else '' }
@@ -2496,8 +2496,8 @@ attachment:
     - "order_county_4": ${ spouse_orders[3].name.text if spouse_waiver_reason['order'] == True else '' }
     - "order_state_4": ${ spouse_orders[3].state if spouse_waiver_reason['order'] == True else '' }
     - "order_case_number_4": ${ spouse_orders[3].number if spouse_waiver_reason['order'] == True else '' }
-    - "user_signature": ${ users[1].name.full(middle="full") if e_signature else '' }
-    - "user__2": ${ users[1].name.full(middle="full") }
+    - "user_signature": ${ users[1].name_full() if e_signature else '' }
+    - "user__2": ${ users[1].name_full() }
     - "user_address": ${ users[1].address.on_one_line(bare=True) }
     - "user_hide_address_cb": ${ True if spouse_hide_address else '' }
     - "user_phone": ${ phone_number_formatted(users[1].phone_number) }
@@ -2513,7 +2513,7 @@ attachment:
   pdf template file: publication_notice.pdf
   fields:
     - "trial_court_county": ${ case_county }
-    - "user__1": ${ users[0].name.full(middle="full") }
+    - "user__1": ${ users[0].name_full() }
     - "user_name_first": ${ users[0].name.first }
     - "user_name_middle": ${ users[0].name.middle }
     - "user_name_last": |
@@ -2535,8 +2535,8 @@ attachment:
     #- "courthouse_address": ${ courthouse_info }
     #- "clerk_phone": ${ trial_court.phone }
     #- "clerk_website": ${ trial_court.website }
-    - "user_signature": ${ users[0].name.full(middle="full") if e_signature else '' }
-    - "user__2": ${ users[0].name.full(middle="full") }
+    - "user_signature": ${ users[0].name_full() if e_signature else '' }
+    - "user__2": ${ users[0].name_full() }
     - "user_address": ${ users[0].address.on_one_line(bare=True) }
     - "user_hide_address_cb": ${ True if hide_address else '' }
     - "user_phone": ${ phone_number_formatted(users[0].phone_number) }
@@ -2552,7 +2552,7 @@ attachment:
   pdf template file: publication_notice.pdf
   fields:
     - "trial_court_county": ${ case_county }
-    - "user__1": ${ users[1].name.full(middle="full") }
+    - "user__1": ${ users[1].name_full() }
     - "user_name_first": ${ users[1].name.first }
     - "user_name_middle": ${ users[1].name.middle }
     - "user_name_last": |
@@ -2572,8 +2572,8 @@ attachment:
     #- "courthouse_address": ${ courthouse_info }
     #- "clerk_phone": ${ trial_court.phone }
     #- "clerk_website": ${ trial_court.website }
-    - "user_signature": ${ users[1].name.full(middle="full") if e_signature else '' }
-    - "user__2": ${ users[1].name.full(middle="full") }
+    - "user_signature": ${ users[1].name_full() if e_signature else '' }
+    - "user__2": ${ users[1].name_full() }
     - "user_address": ${ users[1].address.on_one_line(bare=True) }
     - "user_hide_address_cb": ${ True if spouse_hide_address else '' }
     - "user_phone": ${ phone_number_formatted(users[1].phone_number) }
@@ -2589,11 +2589,11 @@ attachment:
   pdf template file: motion_to_impound.pdf
   fields:      
     - "trial_court_county": ${ case_county }
-    - "user__1": ${ users[0].name.full(middle="full") }
+    - "user__1": ${ users[0].name_full() }
     - "impoundment_reason_member": ${ impoundment_reasons['member'] }
     - "impoundment_reason_other": ${ impoundment_reasons['other'] }
-    - "user_signature": ${ users[0].name.full(middle="full") if e_signature else '' }
-    - "user__2": ${ users[0].name.full(middle="full") }
+    - "user_signature": ${ users[0].name_full() if e_signature else '' }
+    - "user__2": ${ users[0].name_full() }
     - "user_address": ${ users[0].address.on_one_line(bare=True) }
     - "user_hide_address_cb": ${ True if hide_address else '' }
     - "user_phone": ${ phone_number_formatted(users[0].phone_number) }
@@ -2609,7 +2609,7 @@ attachment:
   pdf template file: name_change_order.pdf
   fields:
     - "trial_court_county": ${ case_county }
-    - "user": ${ users[0].name.full(middle="full") }
+    - "user": ${ users[0].name_full() }
 ---
 attachment:
   variable name: spouse_order[i]
@@ -2620,7 +2620,7 @@ attachment:
   pdf template file: name_change_order.pdf
   fields:
     - "trial_court_county": ${ case_county }
-    - "user": ${ users[1].name.full(middle="full") }
+    - "user": ${ users[1].name_full() }
 ---
 attachment:
   variable name: order_to_impound[i]
@@ -2631,7 +2631,7 @@ attachment:
   pdf template file: order_to_impound.pdf
   fields:
     - "trial_court_county": ${ case_county }
-    - "user": ${ users[0].name.full(middle="full") }
+    - "user": ${ users[0].name_full() }
 ---
 attachment:
   variable name: order_to_waive_notice[i]
@@ -2642,7 +2642,7 @@ attachment:
   pdf template file: order_to_waive_notice.pdf
   fields:
     - "trial_court_county": ${ case_county }
-    - "user": ${ users[0].name.full(middle="full") }
+    - "user": ${ users[0].name_full() }
 ---
 attachment:
   variable name: spouse_order_to_waive_notice[i]
@@ -2653,7 +2653,7 @@ attachment:
   pdf template file: order_to_waive_notice.pdf
   fields:
     - "trial_court_county": ${ case_county }
-    - "user": ${ users[1].name.full(middle="full") }
+    - "user": ${ users[1].name_full() }
 
 ---
 ############### Review page
@@ -2668,12 +2668,12 @@ review:
       - users[0].name.first
     button: |
       **Current legal name:**
-      ${ users[0].name.full(middle="full") }
+      ${ users[0].name_full() }
   - Edit: 
       - users[0].new.name.first
     button: |
       **New name:**
-      ${ users[0].new.name.full(middle="full") }
+      ${ users[0].new.name_full() }
   - Edit:
     - users[0].birthdate
     button: |
@@ -2829,13 +2829,13 @@ review:
       - users[1].name.first
     button: |
       **Spouse's current legal name:**
-      ${ users[1].name.full(middle="full") }
+      ${ users[1].name_full() }
     show if: change_spouse_name == 'Yes'
   - Edit: 
       - users[1].new.name.first
     button: |
       **Spouse's new name:**
-      ${ users[1].new.name.full(middle="full") }
+      ${ users[1].new.name_full() }
     show if: change_spouse_name == 'Yes'
   - Edit:
     - users[1].birthdate
@@ -3245,12 +3245,12 @@ review:
       - users[0].name.first
     button: |
       **Current legal name:**
-      ${ users[0].name.full(middle="full") }
+      ${ users[0].name_full() }
   - Edit: 
       - users[0].new.name.first
     button: |
       **New name:**
-      ${ users[0].new.name.full(middle="full") }
+      ${ users[0].new.name_full() }
   - Edit:
     - users[0].birthdate
     button: |
@@ -3427,13 +3427,13 @@ review:
       - users[1].name.first
     button: |
       **Spouse's current legal name:**
-      ${ users[1].name.full(middle="full") }
+      ${ users[1].name_full() }
     show if: change_spouse_name == 'Yes'
   - Edit: 
       - users[1].new.name.first
     button: |
       **Spouse's new name:**
-      ${ users[1].new.name.full(middle="full") }
+      ${ users[1].new.name_full() }
     show if: change_spouse_name == 'Yes'
   - Edit:
     - users[1].birthdate


### PR DESCRIPTION

Previously, it was possible to have leftover text in the .name.last field which would not be removed
if the user used a review screen and changed the person type from Individual to Business.

This PR replaces any use of `.name.full(middle="full")` with `name_full()`, which in a future
version of the AssemblyLine framework will solve this problem by not printing the last name
when the `person_type` is "business"

## How this change was made

This change was made by searching for any repos that had the text `name.full(middle="full") using gh-search,
and then the text was replaced with turbolift --sed as follows:

```bash
turbolift foreach -- bash -lc '
  # 1) enable ** to recurse
  shopt -s globstar

  # 2) for each .yml, replace both " and '\'' variants
  for f in **/*.yml; do
    sed -i "s/name\.full(middle=\"full\")/name_full()/g" "$f"
    sed -i "s/name\.full(middle='\''full'\'')/name_full()/g" "$f"
  done
'
```

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>